### PR TITLE
Adding In-Band Registration (XEP-0077) with Fundamental Changes

### DIFF
--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -19,8 +19,11 @@ abstract class EchoException implements Exception {
   /// A [String] containing the error message associated with the exception.
   final String message;
 
+  /// Embedded `copyWith` method in the abstraction of [EchoException].
+  EchoException copyWith({String? message, int? code});
+
   @override
-  String toString() => ''' Exception: $message ''';
+  String toString() => '''Exception: $message (code: $code)''';
 }
 
 /// [EchoExceptionMapper] is a custom exception class that extends [EchoException].
@@ -113,6 +116,11 @@ class EchoExceptionMapper extends EchoException {
         'Service is currently unavailable, so disconnection occured. Please try again later.',
         510,
       );
+
+  /// Overridden `copyWith` method.
+  @override
+  EchoException copyWith({String? message, int? code}) =>
+      EchoExceptionMapper(message ?? this.message, code ?? this.code);
 }
 
 /// Concrete implementation of the [EchoException] class. It represents an
@@ -124,12 +132,21 @@ class ExtensionException extends EchoException {
   const ExtensionException(super.message, [super.code]);
 
   /// Factory constructor for creating an [ExtensionException] when a feature
-  /// is not implemented.
-  factory ExtensionException.notImplementedFeature(String extensionName) =>
+  /// is not implemented. [String] feature contains a text about which feature
+  /// is not implemented for this extension.
+  factory ExtensionException.notImplementedFeature(
+    String extensionName,
+    String feature,
+  ) =>
       ExtensionException(
-        'This feature is not implemented for the $extensionName extension',
+        '$feature feature is not implemented for the $extensionName extension',
         404,
       );
+
+  /// Overridden `copyWith` method.
+  @override
+  EchoException copyWith({String? message, int? code}) =>
+      ExtensionException(message ?? this.message, code ?? this.code);
 }
 
 /// It is a concrete implementation of the [EchoException] class. It represents
@@ -156,4 +173,10 @@ class WebSocketException extends EchoException {
   /// allowed time limit.
   factory WebSocketException.timedOut() =>
       WebSocketException('WebSocket connection timed out.', 22);
+
+  /// Does not need any implementation at the moment.
+  @override
+  EchoException copyWith({String? message, int? code}) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/src/websocket.dart
+++ b/lib/src/websocket.dart
@@ -456,7 +456,7 @@ class WebSocket extends Protocol {
   @override
   Future<void> disconnect([xml.XmlElement? presence]) async {
     /// Check if the socket is not null and its state is not equal to 3 (closed).
-    if (socket != null && await socket!.stream.isEmpty) {
+    if (socket != null) {
       /// If presence is provided, send the presence using the connection.
       if (presence != null) {
         connection.send(presence);


### PR DESCRIPTION
Introduced In-Band Registration (XEP-0077) mechanism in this commit. For more information about this extension please refer to the branch named `registration` and take a look at the changes and opened issues.

In this commit, there are several changes to the fundamental work structure of the `Echo` package. Prepared groundwork for documentation that will be available soon in the corresponding branch.

**Why This is Important:**

- The addition of the In-Band Registration Extension enhances the user experience by enabling account creation within the `Echo` client. This feature simplifies onboarding for new users and streamlines the registration process.


**Breaking**:

- Changed the `version` variable which is the main part of the initial IQ stanza request. When testing took steps on the Ejabberd server, the server responded error stanza due to the `version`. Changed to version `1.0` to make the package work properly.
- Changed the `_password` type to the `String` only. Due to that was part of `Scram` authentication, there was not any huge difference between passing `Map` and `String` to the constructor. If there will be any need for the `Map` type password to the constructor due ` Salted Challenge Response Authentication Mechanism`, that can be implemented in future updates.
- The work structure of the several methods changed for the `in-band registration` process. For further information, please refer to the corresponding commit.

**Next Steps**:

- As of now, there is no detailed documentation available for the changes made. However, it will be provided in the corresponding branch soon.